### PR TITLE
Fixes "я" in adminhelp.dm. Also added possibility for existence of 2 …

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -92,7 +92,7 @@
 		return
 //	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 //	if(!msg)	return
-	var/original_msg = msg
+	var/original_msg = sanitize_russian(copytext(msg,1,MAX_MESSAGE_LEN))
 
 	//remove our adminhelp verb temporarily to prevent spamming of admins.
 	src.verbs -= /client/verb/adminhelp

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -72,6 +72,8 @@
 /mob/living/simple_animal/hostile/megafauna/bubblegum/New()
 	..()
 	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in mob_list)
+		if(src.z==2)
+			break
 		if(B != src)
 			qdel(src) //There can be only one
 			break


### PR DESCRIPTION
…and more bubblegums one time at centcom. (#32)

* Fixes "я" in adminhelp.dm. Also added possibility for existence of 2 and more bubblegums one time.

* Now 2 and more bubblegums can exist only on Centcom.