### PR TITLE
Summon magic (#40)

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -470,7 +470,7 @@
 /datum/spellbook_entry/summon/magic/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
 	feedback_add_details("wizard_spell_learned",log_name)
 	rightandwrong(1, user, 0)
-	book.uses += 1
+	book.uses += 2
 	active = 1
 	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
 	user << "<span class='notice'>You have cast summon magic and gained an extra charge for your spellbook.</span>"


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: optional name here
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
fix: fixed a few things
wip: added a few works in progress
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
experiment: added an experimental thingy
/:cl:

* FIXED RUNTIME.

* No more warnings.

* Rebalanced nuke ops challenge mode.

* Summon magic now gives 2 points.

* Changes in admins.txt are reverted.